### PR TITLE
export-repro: faithful, de-duplicated crash report bundles

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1223,43 +1223,57 @@ rebuild_pool_artifacts() {
     ## model's lowercase report.md matches REPORT.md and every model-direct
     ## crash was silently skipped.
     ##
-    ## --regenerate (BENCH_REGEN_SKIP_REPORTS=1) skips this whole block: it
-    ## re-derives severity + clustering + rollups from artifacts on disk, but
-    ## rebuilding each crash's REPORT bundle needs the live audit session that
-    ## a re-derivation does not have, and would overwrite hand-edited reports.
-    ## Severity scoring above (bin/reachability) still runs — it only appends a
-    ## Severity line and is exactly what the operator wants refreshed.
-    if [ "${BENCH_REGEN_SKIP_REPORTS:-0}" != "1" ]; then
-      local cdir bundled=0
-      local _md_target_root="$SCRIPT_ROOT/targets/$TARGET_SLUG"
-      for cdir in "$POOL"/crashes/CRASH-*; do
-        [ -d "$cdir" ] || continue
-        ## Already a canonical export-repro bundle? (harness cells, or a
-        ## prior pool pass). Guard on export-repro's exact signature
-        ## heading rather than a filename (report.md / REPORT.md collapse on
-        ## case-insensitive FS) or `## Fields` (a model may emit a Fields
-        ## table in its freeform report without the inlined sanitizer stack
-        ## + reproduce.sh that only export-repro adds — that crash still
-        ## needs bundling).
-        if grep -q '^## Expected sanitizer output' "$cdir"/[Rr][Ee][Pp][Oo][Rr][Tt].md 2>/dev/null; then
-          continue
-        fi
-        RESULTS_DIR="$POOL" TARGET_ROOT="$_md_target_root" TARGET_SLUG="$TARGET_SLUG" \
-          "$SCRIPT_ROOT/bin/export-repro" "$(basename "$cdir")" \
-            --crash-dir "$cdir" --slug "$TARGET_SLUG" \
-          >/dev/null 2>&1 && bundled=$((bundled + 1))
-      done
-      if [ -x "$SCRIPT_ROOT/bin/render-md" ]; then
-        local rep
-        for rep in "$POOL"/crashes/CRASH-*/REPORT.md; do
-          [ -f "$rep" ] || continue
-          python3 "$SCRIPT_ROOT/bin/render-md" "$rep" --html-sibling \
-            >/dev/null 2>&1 || true
-        done
+    ## The export-repro bundle pass runs on EVERY rebuild, including
+    ## --regenerate. It is strictly additive: the per-crash guard below skips
+    ## any crash that already carries a canonical bundle, so every harness
+    ## crash (bundled by bin/audit at audit time) and any hand-edited bundle
+    ## is left byte-for-byte untouched — its REPORT.md is never re-bundled and,
+    ## under --regenerate, its REPORT.html is never re-rendered. The only
+    ## crashes this pass writes are the freeform model-direct baselines, which
+    ## are NEVER bundled at audit time (the bare CTF condition has no harness)
+    ## and otherwise ship with no reproduce.sh / REPORT.md. They need no live
+    ## audit session: export-repro resolves the build recipe from
+    ## targets/<slug>. (Severity scoring via bin/reachability above already ran
+    ## for both conditions and is unaffected.)
+    local _regen=0
+    [ "${BENCH_REGEN_SKIP_REPORTS:-0}" = "1" ] && _regen=1
+    local cdir bundled=0
+    local _md_target_root="$SCRIPT_ROOT/targets/$TARGET_SLUG"
+    for cdir in "$POOL"/crashes/CRASH-*; do
+      [ -d "$cdir" ] || continue
+      ## Already a canonical export-repro bundle? (harness cells, or a prior
+      ## pool pass.) Guard on export-repro's exact signature heading rather
+      ## than a filename (report.md / REPORT.md collapse on case-insensitive
+      ## FS). A matched crash is skipped entirely — never re-bundled or
+      ## re-rendered — so existing good reports survive --regenerate unchanged.
+      if grep -q '^## Expected sanitizer output' "$cdir"/[Rr][Ee][Pp][Oo][Rr][Tt].md 2>/dev/null; then
+        continue
       fi
-      [ "$bundled" -gt 0 ] && log "reproducer bundles created: $bundled ($reason)"
-    else
-      log "regenerate: skipping export-repro REPORT bundle rebuild ($reason)"
+      RESULTS_DIR="$POOL" TARGET_ROOT="$_md_target_root" TARGET_SLUG="$TARGET_SLUG" \
+        "$SCRIPT_ROOT/bin/export-repro" "$(basename "$cdir")" \
+          --crash-dir "$cdir" --slug "$TARGET_SLUG" \
+        >/dev/null 2>&1 && bundled=$((bundled + 1))
+      ## Under --regenerate, render only the bundle we just created so the
+      ## HTML of already-bundled crashes is never rewritten. A full rebuild
+      ## re-renders every crash below instead (to track the severity line
+      ## bin/reachability appended above).
+      if [ "$_regen" = "1" ] && [ -x "$SCRIPT_ROOT/bin/render-md" ] && [ -f "$cdir/REPORT.md" ]; then
+        python3 "$SCRIPT_ROOT/bin/render-md" "$cdir/REPORT.md" --html-sibling \
+          >/dev/null 2>&1 || true
+      fi
+    done
+    if [ "$_regen" != "1" ] && [ -x "$SCRIPT_ROOT/bin/render-md" ]; then
+      local rep
+      for rep in "$POOL"/crashes/CRASH-*/REPORT.md; do
+        [ -f "$rep" ] || continue
+        python3 "$SCRIPT_ROOT/bin/render-md" "$rep" --html-sibling \
+          >/dev/null 2>&1 || true
+      done
+    fi
+    if [ "$bundled" -gt 0 ]; then
+      log "reproducer bundles created: $bundled ($reason)"
+    elif [ "$_regen" = "1" ]; then
+      log "regenerate: no un-bundled crashes (existing bundles untouched) ($reason)"
     fi
   fi
 

--- a/bin/export-repro
+++ b/bin/export-repro
@@ -1405,6 +1405,35 @@ _H1_CRASH_RE = re.compile(r"^# CRASH-[A-Z0-9-]+")
 _TBL_ROW_RE = re.compile(r"^\| ")
 _TBL_SEP_RE = re.compile(r"^\|[-: ]+\|")
 _BLANK_RE = re.compile(r"^\s*$")
+# Any ATX heading. Used to end an active whole-section skip: the original
+# rule only reset on an H2 (`## `), so a narrative the agent placed under an
+# H1 (e.g. `# Mechanism`) after a killed section was swallowed whole.
+_HEADING_RE = re.compile(r"^#{1,6}\s")
+# A stray H1 in the agent body (any `# Heading` that is not the bundle's own
+# crash title). Demoted to H2 so it renders as a subsection rather than a
+# second top-level heading.
+_BODY_H1_RE = re.compile(r"^# (?=\S)")
+# A heading the agent wrote that restates a crash id/title (e.g.
+# `## CRASH-1: heap-buffer-overflow ...`). The bundle already supplies the
+# authoritative `# CRASH-NNNN: ...` title, so the agent's copy is a duplicate
+# title — drop the heading line (its body content is kept). The digit after
+# `CRASH-` keeps real crash ids (CRASH-1, CRASH-001-3) while leaving ordinary
+# hyphenated headings (`## CRASH-resistant design`) untouched.
+_BODY_CRASH_TITLE_RE = re.compile(r"^#{1,6}\s+CRASH-\d")
+# A fenced code block carrying a sanitizer dump. The bundle re-emits the
+# authoritative sanitizer output in its own `## Expected sanitizer output`
+# section, so an agent's copy — under any heading, or embedded inside a
+# narrative section — is a duplicate. Matched by the SHAPE of a real dump (a
+# `<X>Sanitizer:` report line, a `SUMMARY:` line, a numbered stack frame, or a
+# UBSan `file:line:col: runtime error:`) so a passing mention of a sanitizer
+# in source or prose does not cause a code block to be dropped.
+_SANITIZER_DUMP_RE = re.compile(
+    r"(?:Address|Leak|Thread|Memory|HWAddress|UndefinedBehavior)Sanitizer:"
+    r"|^\s*SUMMARY:\s*\w*Sanitizer"
+    r"|^\s*#\d+\s+0x[0-9a-fA-F]+"
+    r"|:\d+:\d+:\s+runtime error:",
+    re.MULTILINE,
+)
 # Agents commonly wrap the field table under a `## Fields` heading. The
 # auto-generated REPORT.md prepends its own Fields table, so we drop the
 # agent's heading + immediately-following table to avoid duplication.
@@ -1422,16 +1451,20 @@ _FIELDS_HEADING_RE = re.compile(r"^#{1,6}\s+Fields\s*$", re.IGNORECASE)
 # `--severity-only` pass the caller runs immediately after; without
 # stripping, they'd sit in the body ahead of the sanitizer stack because
 # reachability ran against the previous-rebuild's report.
+# Match the section heading at ANY level (not just `## `): agents sometimes
+# write these auto-emitted sections as an H1 (`# Reachability`, `# Sanitizer
+# output`). An H2-only match left the H1 form in the body — a duplicate of the
+# harness-appended section — and broke idempotency once demote_body_headings
+# turned the survivor into an H2 that a second pass would then kill.
 _SECTION_REPRO_BLOCKS_RE = re.compile(
-    r"^## *(?:Reproduce"
+    r"^#{1,6} *(?:Reproduce"
     r"|(?:Expected\s+)?[Ss]anitizer\s+[Oo]utput"
     r"|ASan\s+(?:top\s+frames|[Oo]utput)"
     r"|Reachability"
     r"|Severity\s+rationale)(?:\s|$)"
 )
-_SECTION_REPRODUCTION_HEADER_RE = re.compile(r"^## *Reproduction(?:\s|$)")
+_SECTION_REPRODUCTION_HEADER_RE = re.compile(r"^#{1,6} *Reproduction(?:\s|$)")
 _BARE_REPRODUCTION_RE = re.compile(r"^Reproduction:\s*$")
-_NEW_H2_RE = re.compile(r"^## ")
 _END_SKIP_LABEL_RE = re.compile(
     r"^(?:Data Flow|Patch|Reachability|Supplemental|Evidence|Boundary|Classification|Summary|Root Cause|Suggested fix|Notes)[: ]"
 )
@@ -1447,8 +1480,26 @@ _BARE_LABEL_RES = (
     re.compile(r"^[Tt]rusted\s+caller\s+actions:\s"),
     re.compile(r"^[Cc]aller\s+contract:\s"),
     re.compile(r"^[Tt]rigger\s+source:\s"),
+    # Location / bug-class fields some agents (especially freeform
+    # model-direct reports) restate as loose labels right after the Fields
+    # table. They duplicate rows the auto Fields table already emits — Dedup
+    # frames carries file:function:line, Primitive carries the bug class — so
+    # drop them from the body like the restated fields above, rather than
+    # leave them as orphaned `Label: value` lines ahead of the narrative.
+    # The value pattern is deliberately tight (a single token for
+    # file/function/line, a short class-name run for class) so a narrative
+    # sentence that merely begins with one of these words — "File: the parser
+    # reads ...", "Class: this is an instance of ..." — is NOT mistaken for a
+    # field restatement and dropped.
+    re.compile(r"^File:\s+\S+\s*$"),
+    re.compile(r"^Function:\s+\S+\s*$"),
+    re.compile(r"^Line:\s+\S+\s*$"),
+    re.compile(r"^(?:Bug\s+)?[Cc]lass:\s+[\w()\- ]{1,40}\s*$"),
 )
 _AUTO_SEVERITY_RE = re.compile(r"^-?\s*\*\*Severity\*\*\s*:")
+# Kept metadata lines (strip leaves these in the body); skipped, not treated as
+# narrative, when deciding whether the narrative already has a heading.
+_STRATEGY_LINE_RE = re.compile(r"^(?:Strategy|Advisory):\s", re.IGNORECASE)
 
 
 # Prose `## Fix` (or near-variant) sections agents write between Summary
@@ -1485,6 +1536,7 @@ def extract_fix_section(text: str) -> tuple[str, str]:
 def strip_audit_sections(text: str) -> str:
     out: list[str] = []
     skip = False
+    fields_skip = False
     # 0 = haven't seen the H1 yet; 1 = inside the H1's preamble (eat
     # blanks + a `## Fields` heading + the field table); 2 = preamble
     # done.
@@ -1509,7 +1561,25 @@ def strip_audit_sections(text: str) -> str:
             if _TBL_SEP_RE.match(line_no_nl):
                 continue
             ate_h1_table = 2  # First real body line — preamble is over.
-        # Whole-block kills.
+        # Drop the `## Fields` heading + the table that follows it: the
+        # bundle's auto-header already emits a Fields table, so the agent's
+        # copy would render as a duplicate. Unlike the whole-block kills
+        # below, this eats ONLY the heading and its table lines (blank /
+        # row / separator). The first line that is not part of the table
+        # ends the skip and is processed normally — so narrative prose the
+        # agent placed after the table (under an H1 like `# Mechanism`, or
+        # under no heading at all) is preserved rather than swallowed.
+        if _FIELDS_HEADING_RE.match(line_no_nl):
+            fields_skip = True
+            continue
+        if fields_skip:
+            if (_BLANK_RE.match(line_no_nl)
+                    or _TBL_ROW_RE.match(line_no_nl)
+                    or _TBL_SEP_RE.match(line_no_nl)):
+                continue
+            fields_skip = False  # End of the table — fall through.
+        # Whole-block kills: these sections are re-appended at the end of
+        # the rebuilt bundle, so drop everything up to the next heading.
         if _SECTION_REPRODUCTION_HEADER_RE.match(line_no_nl):
             skip = True
             continue
@@ -1519,19 +1589,18 @@ def strip_audit_sections(text: str) -> str:
         if _SECTION_REPRO_BLOCKS_RE.match(line_no_nl):
             skip = True
             continue
-        # Drop any `## Fields` section the agent wrote in the body. The
-        # auto-header at the top of the bundle already provides one, and
-        # leaving the agent's behind produces a duplicate Fields table
-        # in the rendered HTML. Only relevant when the agent put prose
-        # between the H1 and `## Fields` (so the H1 preamble didn't eat it).
-        if _FIELDS_HEADING_RE.match(line_no_nl):
-            skip = True
-            continue
-        if skip and _NEW_H2_RE.match(line_no_nl):
+        # End an active whole-section skip at the next heading of ANY level
+        # (not just H2) or a bare-label section intro.
+        if skip and _HEADING_RE.match(line_no_nl):
             skip = False
         if skip and _END_SKIP_LABEL_RE.match(line_no_nl):
             skip = False
         if skip:
+            continue
+        # Drop a heading that just restates the crash id/title — the bundle
+        # already carries the authoritative `# CRASH-NNNN: ...` title. Only
+        # the heading line goes; the section's body content stays.
+        if _BODY_CRASH_TITLE_RE.match(line_no_nl):
             continue
         if _FULL_ORIGINAL_RE.match(line_no_nl):
             continue
@@ -1549,6 +1618,193 @@ def strip_audit_sections(text: str) -> str:
         blank_run = False
         out.append(raw_line)
     return "".join(out)
+
+
+def demote_body_headings(text: str) -> str:
+    """Demote stray H1 lines (`# Foo` → `## Foo`) in an agent body.
+
+    The bundle supplies the single H1 crash title; any H1 the agent wrote
+    in the body (e.g. `# Mechanism`) would otherwise render as a second
+    top-level heading and, when its body was stripped, as an empty one.
+    Lines inside fenced code blocks are left untouched. Idempotent: an H2
+    is never matched, so a second pass is a no-op.
+    """
+    out: list[str] = []
+    in_fence = False
+    for raw_line in text.splitlines(keepends=True):
+        stripped = raw_line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            out.append(raw_line)
+            continue
+        if not in_fence and _BODY_H1_RE.match(raw_line):
+            raw_line = "#" + raw_line  # "# Foo" -> "## Foo"
+        out.append(raw_line)
+    return "".join(out)
+
+
+# Sections the bundle re-emits itself — never carry the agent's copy. Used by
+# the conservative `recover_agent_prose` fallback (section-based, independent
+# of the line-greedy strip so a bug in one cannot silently break the other).
+_AUTO_SECTION_RE = re.compile(
+    r"^#{1,6}\s+(?:Fields"
+    r"|Reproduce|Reproduction"
+    r"|(?:Expected\s+)?[Ss]anitizer\s+[Oo]utput"
+    r"|ASan\b"
+    r"|Reachability\b"
+    r"|Severity\s+rationale)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_structured_line(stripped: str) -> bool:
+    """A non-narrative body line: table row/separator, bare-label field,
+    the auto-Severity bullet, or the `Full original output:` pointer."""
+    if stripped.startswith("|"):
+        return True
+    if any(p.match(stripped) for p in _BARE_LABEL_RES):
+        return True
+    if _AUTO_SEVERITY_RE.match(stripped) or _FULL_ORIGINAL_RE.match(stripped):
+        return True
+    return False
+
+
+def _body_has_prose(text: str) -> bool:
+    """True if `text` carries narrative — a non-blank line that is not a
+    heading, table row, bare-label field, or auto-emitted boilerplate."""
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _is_structured_line(stripped):
+            continue
+        return True
+    return False
+
+
+def recover_agent_prose(text: str) -> str:
+    """Conservative fallback recovery of an agent body.
+
+    Drops only the leading crash-title H1 and the known auto-emitted
+    sections (Fields, Reproduce/Reproduction, sanitizer output, Reachability,
+    Severity rationale) by heading, plus stray structured lines, keeping
+    every other line verbatim. Section-based and deliberately independent of
+    `strip_audit_sections` so it can still surface the narrative if that
+    line-greedy function ever over-strips.
+    """
+    out: list[str] = []
+    drop = False
+    for raw_line in text.splitlines(keepends=True):
+        line = raw_line.rstrip("\n")
+        if _H1_CRASH_RE.match(line):
+            continue
+        if _HEADING_RE.match(line):
+            drop = bool(_AUTO_SECTION_RE.match(line))
+            if drop:
+                continue
+        if drop:
+            continue
+        if _is_structured_line(line):
+            continue
+        out.append(raw_line)
+    return "".join(out)
+
+
+def strip_sanitizer_blocks(text: str) -> str:
+    """Drop fenced code blocks whose content is a sanitizer dump.
+
+    The bundle re-emits the authoritative sanitizer output in its own
+    `## Expected sanitizer output` section, so an agent's copy — under any
+    heading (`## Observed`, `## ASan Evidence`, ...) or embedded inside a
+    narrative section — is a duplicate. Matched by content (a sanitizer
+    signature inside the fence), not by heading name, so it is robust to
+    whatever the agent titled it. A non-sanitizer code block (source, a
+    reproduce command) is kept verbatim. The enclosing heading and any
+    surrounding prose stay; an emptied heading is dropped by bin/render-md.
+    """
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    i, n = 0, len(lines)
+    while i < n:
+        fence = lines[i].lstrip()[:3]
+        if fence in ("```", "~~~"):
+            j = i + 1
+            while j < n and lines[j].lstrip()[:3] != fence:
+                j += 1
+            if j >= n:
+                # No closing fence — malformed. Keep this line and process the
+                # rest normally rather than swallowing the document tail.
+                out.append(lines[i])
+                i += 1
+                continue
+            if _SANITIZER_DUMP_RE.search("".join(lines[i + 1:j])):
+                i = j + 1                  # drop open fence + content + close fence
+                continue
+            out.extend(lines[i:j + 1])     # keep the block verbatim
+            i = j + 1
+            continue
+        out.append(lines[i])
+        i += 1
+    return "".join(out)
+
+
+def _squash_blank_runs(text: str) -> str:
+    """Collapse runs of blank lines to a single blank — block removal can
+    leave a double blank where a fenced dump used to sit. Applied once at the
+    end so the result is stable on a second render_agent_body pass."""
+    out: list[str] = []
+    blank = False
+    for line in text.splitlines(keepends=True):
+        if line.strip() == "":
+            if blank:
+                continue
+            blank = True
+        else:
+            blank = False
+        out.append(line)
+    return "".join(out)
+
+
+def _ensure_leading_heading(text: str) -> str:
+    """Guarantee the agent narrative sits under a section heading.
+
+    Once the auto-emitted sections, field restatements, duplicate sanitizer
+    dumps and restated crash titles are stripped, a body can lead with bare
+    narrative prose — either because the agent wrote no heading, or because the
+    only heading it wrote restated the crash title (dropped above). The bundle
+    would then render that prose with no section title. Prepend a canonical
+    `## Summary` in that case. No-op when the body already leads with a heading
+    (of any level) or carries no narrative. The kept `Strategy:` metadata line
+    is skipped, not treated as narrative.
+    """
+    lines = text.splitlines(keepends=True)
+    for idx, raw in enumerate(lines):
+        s = raw.strip()
+        if not s:
+            continue
+        if s.startswith("#"):
+            return text                      # already under a heading
+        if _is_structured_line(s) or _STRATEGY_LINE_RE.match(s):
+            continue                          # skip kept metadata (Strategy:, ...)
+        # First narrative line, with no heading above it — head it.
+        sep = "" if idx == 0 or lines[idx - 1].strip() == "" else "\n"
+        lines.insert(idx, sep + "## Summary\n\n")
+        return "".join(lines)
+    return text                              # no narrative to head
+
+
+def render_agent_body(body_text: str) -> str:
+    """Turn a raw agent report body into the narrative spliced into the
+    bundle: strip the auto-emitted sections, drop duplicate sanitizer dumps,
+    demote stray H1s, and ensure the narrative sits under a heading. If
+    stripping leaves no prose but the original had some, fall back to the
+    conservative section-based recovery (independent of the line-greedy strip)
+    so the bundle never ships an empty narrative.
+    """
+    rendered = strip_sanitizer_blocks(strip_audit_sections(body_text))
+    if not _body_has_prose(rendered) and _body_has_prose(body_text):
+        rendered = strip_sanitizer_blocks(recover_agent_prose(body_text))
+    return _ensure_leading_heading(_squash_blank_runs(demote_body_headings(rendered)))
 
 
 def read_field_from_fields_table(path: Optional[Path], label: str) -> str:
@@ -2575,7 +2831,7 @@ def build_report_md(*, crash_id: str, primitive_label: str, severity_value: str,
     fix_section = ""
     if report_md is not None and report_md.is_file():
         body_text = report_md.read_text(encoding="utf-8", errors="replace")
-        body_stripped = strip_audit_sections(body_text)
+        body_stripped = render_agent_body(body_text)
         # Lift the prose `## Fix` section out of the body so it sits at
         # the END of the rebuilt report — after Expected sanitizer output
         # and Reproduce, alongside the auto-appended Reachability /

--- a/tests/test_benchmark.sh
+++ b/tests/test_benchmark.sh
@@ -427,8 +427,17 @@ regen_rc=$?
 assert_eq "0" "$regen_rc" "T9r-a: --regenerate exits 0"
 assert_match 'no cells launched' "$regen_out" \
   "T9r-b: --regenerate does not launch cells"
-assert_match 'skipping export-repro REPORT bundle rebuild' "$regen_out" \
-  "T9r-c: --regenerate skips the per-crash export-repro bundle rebuild"
+# --regenerate now runs the bundle pass too, but it is strictly additive: the
+# per-crash signature guard skips every already-bundled crash, so it never
+# re-bundles or re-renders an existing good report. It DOES bundle a crash that
+# has no canonical bundle yet — the freeform model-direct baseline in a real
+# run — giving it the reproduce.sh / REPORT.md it otherwise never gets.
+assert_not_match 'skipping export-repro REPORT bundle rebuild' "$regen_out" \
+  "T9r-c: --regenerate no longer wholesale-skips the bundle pass"
+assert_match 'reproducer bundles created' "$regen_out" \
+  "T9r-c2: --regenerate bundles a crash that had no canonical bundle yet"
+assert_file_exists "$dbench/pool/crashes/CRASH-0001/reproduce.sh" \
+  "T9r-c3: the newly bundled crash gains a reproduce.sh under --regenerate"
 assert_not_match 'cell .* — starting' "$regen_out" \
   "T9r-d: --regenerate prints no cell-start lines"
 cells_after=$(find "$dbench/cells" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')

--- a/tests/test_export_repro_py.py
+++ b/tests/test_export_repro_py.py
@@ -813,6 +813,275 @@ stripped_table_2 = er.strip_audit_sections(stripped_table)
 assert_eq(stripped_table, stripped_table_2,
           "strip_audit_sections (table form): idempotent")
 
+# 5f. Narrative prose AFTER the `## Fields` table must survive.
+#
+# Why this test exists: some agents (notably weaker instruction-followers)
+# write the root-cause narrative as loose prose right after their Fields
+# table, under an H1 like `# Mechanism` or no heading at all — never under a
+# canonical `## Summary` / `## Root Cause` H2. The old `## Fields` kill set a
+# skip flag that only reset at the next H2, so that prose was swallowed whole
+# (everything up to `## Reachability`), shipping a bundle with an empty body.
+# The Fields kill must now eat ONLY the heading + table and stop at the first
+# non-table line.
+fields_then_prose_input = """\
+Boundary: sqlite3
+Strategy: S7
+
+# Mechanism
+
+## Fields
+
+| Field     | Value     |
+| :-------- | :-------- |
+| Primitive | uaf_write |
+| Severity  | Low (26)  |
+
+A trusted caller frees the cached result object; the later write to it
+is a use-after-free. This is the whole point of the report.
+
+## Reachability — external callers
+
+callers: 136
+
+## Severity rationale
+
+score=26
+"""
+rendered_body = er.render_agent_body(fields_then_prose_input)
+assert_in("use-after-free. This is the whole point", rendered_body,
+          "render_agent_body: narrative after Fields table preserved")
+assert_not_in("| Primitive | uaf_write", rendered_body,
+              "render_agent_body: Fields table still stripped (no duplicate)")
+assert_not_in("| Severity  | Low (26)", rendered_body,
+              "render_agent_body: Fields severity row stripped")
+assert_not_in("callers: 136", rendered_body,
+              "render_agent_body: Reachability section stripped")
+assert_not_in("score=26", rendered_body,
+              "render_agent_body: Severity rationale section stripped")
+# The stray H1 is demoted to an H2 subsection (no second top-level heading).
+assert_in("## Mechanism", rendered_body,
+          "render_agent_body: stray body H1 demoted to H2")
+assert_not_in("\n# Mechanism", "\n" + rendered_body,
+              "render_agent_body: no bare H1 left in body")
+# Idempotent.
+assert_eq(rendered_body, er.render_agent_body(rendered_body),
+          "render_agent_body: idempotent")
+
+# 5g. demote_body_headings leaves headings inside fenced code blocks alone
+# (a `# comment` in a shell snippet is not a Markdown heading).
+fenced = "## Root Cause\n\n```sh\n# not a heading, a shell comment\necho hi\n```\n\n# Real Heading\n"
+demoted = er.demote_body_headings(fenced)
+assert_in("# not a heading, a shell comment", demoted,
+          "demote_body_headings: fenced '# comment' untouched")
+assert_not_in("## not a heading", demoted,
+              "demote_body_headings: fenced comment not demoted")
+assert_in("## Real Heading", demoted,
+          "demote_body_headings: real body H1 demoted to H2")
+
+# 5h. _body_has_prose distinguishes narrative from structured-only bodies.
+assert_eq(True, er._body_has_prose("## Summary\n\nReal narrative line.\n"),
+          "_body_has_prose: narrative detected")
+assert_eq(False, er._body_has_prose("## Fields\n\n| A | B |\n| :- | :- |\n| x | y |\n"),
+          "_body_has_prose: table-only body has no prose")
+assert_eq(False, er._body_has_prose("Boundary: x\nSurface: y\n- **Severity**: 5\n"),
+          "_body_has_prose: bare-label/severity-only body has no prose")
+
+# 5i. recover_agent_prose (the auto-repair fallback) keeps narrative verbatim
+# while dropping the auto-emitted sections, independent of strip's logic.
+recovered = er.recover_agent_prose(
+    "# CRASH-Z-1\n\n## Description\n\nThe defect is X.\n\n## Reachability\n\nc:9\n"
+)
+assert_in("The defect is X.", recovered,
+          "recover_agent_prose: narrative kept")
+assert_in("## Description", recovered,
+          "recover_agent_prose: non-auto heading kept")
+assert_not_in("CRASH-Z-1", recovered,
+              "recover_agent_prose: crash-title H1 dropped")
+assert_not_in("c:9", recovered,
+              "recover_agent_prose: Reachability auto-section dropped")
+
+# 5j. render_agent_body falls back to recovery when strip yields no prose.
+# Guard against future strip regressions: if strip_audit_sections ever
+# over-strips a body to headings-only, the original narrative is still
+# surfaced rather than shipped empty.
+_real_strip = er.strip_audit_sections
+try:
+    er.strip_audit_sections = lambda _t: "## Mechanism\n"  # simulate over-strip
+    salvaged = er.render_agent_body("## Mechanism\n\nLoad-bearing narrative.\n")
+    assert_in("Load-bearing narrative.", salvaged,
+              "render_agent_body: fallback recovers prose when strip empties body")
+finally:
+    er.strip_audit_sections = _real_strip
+
+# 5k. Location/bug-class labels an agent restates as loose lines after the
+# Fields table are redundant with the auto table (Dedup frames = file:func:line,
+# Primitive = bug class) and must be stripped from the body — never left as
+# orphaned `Label: value` lines ahead of the narrative. The narrative stays.
+restated_labels_input = """\
+## Fields
+
+| Field     | Value          |
+| :-------- | :------------- |
+| Primitive | heap-uaf       |
+
+File: ext/misc/closure.c
+Function: closureDequote
+Line: 445
+Bug Class: heap-buffer-overflow (read)
+Class: memory-safety
+
+The `closureDequote` function fails to null-terminate the output buffer.
+"""
+stripped_labels = er.render_agent_body(restated_labels_input)
+for lab in ("File:", "Function:", "Line:", "Bug Class:", "Class:"):
+    assert_not_in(lab, stripped_labels,
+                  f"render_agent_body: restated `{lab}` label dropped from body")
+assert_in("fails to null-terminate", stripped_labels,
+          "render_agent_body: narrative kept after dropping restated labels")
+assert_not_in("| Primitive", stripped_labels,
+              "render_agent_body: Fields table still stripped")
+assert_eq(False, er._body_has_prose("File: a.c\nFunction: f\nBug Class: uaf\n"),
+          "_body_has_prose: a body of only restated labels has no prose")
+
+# 5l. Duplicate sanitizer dumps. Agents copy the sanitizer output into the body
+# under arbitrary headings (`## Observed`, `## ASan Evidence`, ...) or inside a
+# narrative section; the bundle re-emits the authoritative `## Expected
+# sanitizer output`, so the agent's copy must be dropped by CONTENT (the
+# sanitizer signature in the fence), not by heading name. Surrounding prose and
+# non-sanitizer code blocks stay.
+dup_sanitizer_input = """\
+## Observed (sanitizer.txt)
+
+```
+==123==ERROR: AddressSanitizer: stack-buffer-overflow on address 0xdead
+    #0 0x1 in strcat
+SUMMARY: AddressSanitizer: stack-buffer-overflow harness.c:59 in main
+```
+
+The write of 2001 bytes overflows the 500-byte `cmdbuf`.
+
+## Patch
+
+```c
+strncat(cmdbuf, s, sizeof(cmdbuf) - strlen(cmdbuf) - 1);
+```
+"""
+sd = er.render_agent_body(dup_sanitizer_input)
+assert_not_in("AddressSanitizer", sd,
+              "render_agent_body: duplicate sanitizer dump dropped from body")
+assert_in("The write of 2001 bytes overflows", sd,
+          "render_agent_body: prose around the sanitizer dump preserved")
+assert_in("strncat(cmdbuf", sd,
+          "render_agent_body: non-sanitizer (patch) code block kept")
+assert_eq(sd, er.render_agent_body(sd),
+          "render_agent_body: sanitizer-dedup is idempotent")
+# strip_sanitizer_blocks in isolation: only the sanitizer fence goes.
+only_blocks = er.strip_sanitizer_blocks(
+    "```\nrun: ./reproduce.sh\n```\n\n```\nAddressSanitizer: heap-buffer-overflow\n```\n")
+assert_in("run: ./reproduce.sh", only_blocks,
+          "strip_sanitizer_blocks: keeps a non-sanitizer code block")
+assert_not_in("AddressSanitizer", only_blocks,
+              "strip_sanitizer_blocks: drops the sanitizer code block")
+
+# 5m. A heading that restates the crash id/title (the bundle supplies the real
+# `# CRASH-NNNN: ...` title) is dropped; its body content stays.
+dup_title_input = """\
+## Classification
+
+## CRASH-1: heap-buffer-overflow in the decimal extension
+
+### Trigger
+
+A crafted decimal literal.
+"""
+dt = er.render_agent_body(dup_title_input)
+assert_not_in("CRASH-1:", dt,
+              "render_agent_body: restated CRASH-id title heading dropped")
+assert_in("A crafted decimal literal.", dt,
+          "render_agent_body: body under the restated title preserved")
+assert_in("Trigger", dt,
+          "render_agent_body: subsection headings under the title preserved")
+
+# 5n. Headingless narrative gets a canonical `## Summary`. Agents (esp. freeform
+# model-direct) often write the whole writeup as bare prose with no heading, or
+# the only heading they wrote restated the crash title (dropped above). Either
+# way the narrative must not render without a section heading.
+noheading_input = """\
+## Fields
+
+| Field     | Value          |
+| :-------- | :------------- |
+| Primitive | heap-uaf       |
+
+ASan confirms a heap-buffer-overflow in closureDequote when a caller passes
+a malformed bracket-quoted argument.
+"""
+nh = er.render_agent_body(noheading_input)
+assert nh.lstrip().startswith("## Summary"), \
+    f"render_agent_body: headingless narrative gets a ## Summary heading (got {nh[:40]!r})"
+assert_in("ASan confirms a heap-buffer-overflow", nh,
+          "render_agent_body: the narrative itself is preserved under the heading")
+assert_eq(nh, er.render_agent_body(nh),
+          "render_agent_body: heading insertion is idempotent")
+# A body that already leads with a heading is NOT given a second one.
+headed = er.render_agent_body("## Root Cause\n\nThe parser overflows the stack buffer here.\n")
+assert_not_in("## Summary", headed,
+              "render_agent_body: no spurious ## Summary when body already has a heading")
+# A Strategy: metadata line is skipped, not treated as the narrative.
+strat = er.render_agent_body("Strategy: S5\n\nThe overflow occurs because the loop never bounds-checks.\n")
+assert strat.count("## Summary") == 1 and "Strategy: S5" in strat, \
+    "render_agent_body: Strategy line kept, Summary heads the real narrative"
+# A body with no narrative at all gets no heading (nothing to head).
+assert_not_in("## Summary", er.render_agent_body("## Fields\n\n| A | B |\n| :- | :- |\n| x | y |\n"),
+              "render_agent_body: no ## Summary when there is no narrative")
+
+# 5o. Robustness hardening — narrative must never be lost to over-eager rules.
+# (a) A sentence that begins with a label word is narrative, not a restated
+#     field — keep it. Real single-token restatements still go.
+labels_prose = er.render_agent_body(
+    "## Summary\n\nFile: the parser reads one element past the end of buf.\n"
+    "Class: this is an instance of a broader unchecked-length pattern.\n")
+assert_in("the parser reads one element past", labels_prose,
+          "5o-a: narrative sentence starting 'File:' is kept")
+assert_in("broader unchecked-length pattern", labels_prose,
+          "5o-a: narrative sentence starting 'Class:' is kept")
+assert_not_in("ext/misc/closure.c", er.render_agent_body("## Summary\n\nx\n\nFile: ext/misc/closure.c\n"),
+              "5o-a: single-token File: restatement still dropped")
+
+# (b) An UNCLOSED sanitizer fence must not swallow the rest of the document.
+unclosed = er.render_agent_body(
+    "## Observed\n\n```\n==1==ERROR: AddressSanitizer: heap-buffer-overflow\n"
+    "## Root Cause\n\nThe real narrative that explains the bug.\n")
+assert_in("real narrative that explains", unclosed,
+          "5o-b: narrative after an unclosed sanitizer fence is preserved")
+
+# (c) A non-sanitizer code block that merely MENTIONS a sanitizer / 'runtime
+#     error:' is kept; a real dump is dropped.
+mention = er.render_agent_body(
+    "## Summary\n\n```c\n// guard against the runtime error: divide by zero\n"
+    "if (d) q = n / d;\n```\n")
+assert_in("divide by zero", mention,
+          "5o-c: code block merely mentioning 'runtime error:' is kept")
+assert_in("q = n / d;", mention, "5o-c: its code is kept")
+realdump = er.render_agent_body(
+    "## Observed\n\n```\n    #0 0x55 in foo bar.c:9\nSUMMARY: AddressSanitizer: heap-buffer-overflow\n```\n\nNote.\n")
+assert_not_in("AddressSanitizer", realdump, "5o-c: a real sanitizer dump is still dropped")
+
+# (d) `## CRASH-<word>` (a real heading) is kept; only `CRASH-<digit>` ids drop.
+assert_in("CRASH-resistant", er.render_agent_body("## CRASH-resistant design\n\nNarrative.\n"),
+          "5o-d: a 'CRASH-word' heading is not mistaken for a crash-id title")
+assert_not_in("CRASH-2", er.render_agent_body("## CRASH-2: heap overflow in foo\n\nNarrative.\n"),
+              "5o-d: a 'CRASH-<digit>' restated title is dropped")
+
+# (e) Auto-emitted sections written as an H1 (`# Reproduction`, `# Reachability`)
+#     are killed like their H2 form — no duplicate section leaks, and the
+#     result is idempotent.
+h1dup = er.render_agent_body(
+    "# Reproduction\n\n1. call foo()\n2. call bar()\n\n# Root Cause\n\nThe pointer is freed early.\n")
+assert_not_in("call foo()", h1dup, "5o-e: an H1 '# Reproduction' section is dropped")
+assert_in("The pointer is freed early", h1dup, "5o-e: the narrative section is kept")
+assert_eq(h1dup, er.render_agent_body(h1dup), "5o-e: H1-section handling is idempotent")
+
 cpp_harness_dir = TMP / "cpp-harness"
 cpp_harness_dir.mkdir()
 (cpp_harness_dir / "harness.cpp").write_text("#include <iostream>\nint main(int,char**){return 0;}\n",


### PR DESCRIPTION
## Summary

Reworks how the maintainer-facing `REPORT.md` is rebuilt from an agent's freeform crash report so the narrative is **complete, de-duplicated, and consistently structured**. Most visible on the model-direct baseline, but harness crashes hit the same issues. All changes touch only the rendered body — never crash detection, field extraction, or the Fields table — and the agent's original is preserved in `.audit/report.md`.

## What changed

- **Preserve narrative** — the `## Fields` strip was greedy and swallowed any prose the agent wrote after the table (under an H1 like `# Mechanism`, or no heading). It now eats only the heading + table; section skips reset on a heading of any level.
- **De-duplicate harness-owned content** the agent restated (matched by content/shape, robust to heading names): sanitizer dumps (the bundle re-emits the authoritative `## Expected sanitizer output`), the restated crash title (`## CRASH-<id>: …`), and `File:`/`Function:`/`Line:`/`Class:` field labels (already in Dedup frames / Primitive). Auto-sections written as an H1 (`# Reproduction`, `# Reachability`) are dropped like their H2 form.
- **Guarantee a heading** — headingless narrative gets a canonical `## Summary`.
- **`bin/benchmark`** — the reproducer-bundle pass now runs under `--regenerate` too. Strictly additive: a per-crash signature guard skips every already-bundled crash, so model-direct crashes (never bundled at audit time) finally get a `reproduce.sh`/`REPORT.md` while existing bundles stay byte-for-byte untouched.

## Safety / robustness

Matching is deliberately tight so narrative is never lost: sentences that merely begin with a field word are kept, an unclosed code fence is not swallowed, a passing mention of a sanitizer doesn't drop a code block, and a `## CRASH-word` heading isn't mistaken for a crash id. `render_agent_body` is idempotent (verified across all reports + a fuzz sweep).

## Tests

New coverage for narrative preservation, each de-dup rule, the heading guarantee, additive `--regenerate` bundling, and the robustness edge cases. Full suite green.