### PR TITLE
fix(tests): resolve macOS sysctl, stdin deadlock, and deprecation warning test failures.

### DIFF
--- a/lib/benchmark_runner.py
+++ b/lib/benchmark_runner.py
@@ -1059,7 +1059,7 @@ def run_harness(
                         env=environment, stdout=stream, stderr=subprocess.STDOUT,
                     ).returncode
                 else:
-                    rc = subprocess.run(command, cwd=facade, env=environment, stdout=stream, stderr=subprocess.STDOUT, check=False).returncode
+                    rc = subprocess.run(command, cwd=facade, env=environment, stdin=subprocess.DEVNULL, stdout=stream, stderr=subprocess.STDOUT, check=False).returncode
             finally:
                 # Reap escaped cell processes even if the launch raised
                 # (OSError, timeout-helper failure) — the leak this guards

--- a/lib/llm_invoke.py
+++ b/lib/llm_invoke.py
@@ -1225,8 +1225,9 @@ def _run_agent_process(
     if turn_cap <= 0 and not health_watchdog:
         with raw.open("w", encoding="utf-8") as sink:
             completed = subprocess.run(
-                launch_command, input=input_text, stdout=sink,
-                stderr=subprocess.STDOUT, text=True, cwd=cwd, env=environment,
+                launch_command, input=input_text,
+                stdin=subprocess.DEVNULL if input_text is None else None,
+                stdout=sink, stderr=subprocess.STDOUT, text=True, cwd=cwd, env=environment,
                 check=False,
             )
         return _normalize_native_turn_limit(
@@ -1241,7 +1242,7 @@ def _run_agent_process(
     with raw.open("w", encoding="utf-8") as sink:
         process = subprocess.Popen(
             launch_command,
-            stdin=subprocess.PIPE if input_text is not None else None,
+            stdin=subprocess.PIPE if input_text is not None else subprocess.DEVNULL,
             stdout=sink,
             stderr=subprocess.STDOUT,
             text=True,

--- a/lib/process_tree.py
+++ b/lib/process_tree.py
@@ -138,6 +138,42 @@ def _pids_with_token(token: str) -> list[int]:
                 continue
         return pids
 
+    if sys.platform == "darwin":
+        import ctypes
+        raw = token.encode()
+        try:
+            output = subprocess.check_output(["ps", "-ax", "-o", "pid="], text=True)
+        except (OSError, subprocess.SubprocessError):
+            return []
+        CTL_KERN, KERN_PROCARGS2 = 1, 49
+        libc = ctypes.CDLL(None)
+        for line in output.splitlines():
+            pid_text = line.strip()
+            if not pid_text.isdigit():
+                continue
+            pid = int(pid_text)
+            mib = (ctypes.c_int * 3)(CTL_KERN, KERN_PROCARGS2, pid)
+            size = ctypes.c_size_t(0)
+            if libc.sysctl(mib, 3, None, ctypes.byref(size), None, 0) != 0:
+                continue
+            buf = ctypes.create_string_buffer(size.value)
+            if libc.sysctl(mib, 3, buf, ctypes.byref(size), None, 0) != 0:
+                continue
+            data = buf.raw
+            if len(data) < 4:
+                continue
+            argc = int.from_bytes(data[:4], sys.byteorder)
+            idx = 4
+            while idx < len(data) and data[idx] != 0:
+                idx += 1
+            while idx < len(data) and data[idx] == 0:
+                idx += 1
+            strings = data[idx:].split(b"\0")
+            env_strings = strings[argc:]
+            if raw in env_strings:
+                pids.append(pid)
+        return pids
+
     # Environment snapshot first: a pid it holds that the later argv snapshot
     # has lost merely exited, whereas taking argv first drops any process born
     # between the two calls — the still-spawning leak this exists to catch.

--- a/lib/timeout.py
+++ b/lib/timeout.py
@@ -24,8 +24,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Mapping, Sequence
 
-warnings.filterwarnings("ignore", category=DeprecationWarning)
-
 
 def run_timeout(
     command: Sequence[str],
@@ -42,14 +40,6 @@ def run_timeout(
     text: bool = False,
 ) -> subprocess.CompletedProcess:
     """Run a command through the portable process-tree timeout wrapper."""
-    kwargs: dict = {"cwd": cwd, "env": env, "stdout": stdout, "stderr": stderr, "text": text, "check": False}
-    if capture_output:
-        kwargs["capture_output"] = True
-    if input is not None:
-        kwargs["input"] = input
-    elif not capture_output:
-        kwargs["stdin"] = subprocess.DEVNULL
-
     return subprocess.run(
         [
             sys.executable,
@@ -59,7 +49,15 @@ def run_timeout(
             str(rss_mb),
             *command,
         ],
-        **kwargs,
+        cwd=cwd,
+        env=env,
+        capture_output=capture_output,
+        stdout=stdout,
+        stderr=stderr,
+        stdin=subprocess.DEVNULL if input is None else None,
+        input=input,
+        text=text,
+        check=False,
     )
 
 
@@ -177,7 +175,18 @@ def main():
     if not cmd:
         _die("missing command")
 
-    pid = os.fork()
+    # Keep this compatibility warning out of command diagnostics without
+    # changing the warning policy of processes that import this module.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=(
+                r"This process .* is multi-threaded, use of fork\(\) may "
+                r"lead to deadlocks in the child\."
+            ),
+            category=DeprecationWarning,
+        )
+        pid = os.fork()
     if pid == 0:
         # setsid (not setpgrp) so the child has no controlling terminal.
         # setpgrp alone moves the child to a background pgrp while leaving

--- a/lib/timeout.py
+++ b/lib/timeout.py
@@ -19,9 +19,12 @@ import subprocess
 import sys
 import tempfile
 import time
+import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Mapping, Sequence
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
 def run_timeout(
@@ -39,6 +42,14 @@ def run_timeout(
     text: bool = False,
 ) -> subprocess.CompletedProcess:
     """Run a command through the portable process-tree timeout wrapper."""
+    kwargs: dict = {"cwd": cwd, "env": env, "stdout": stdout, "stderr": stderr, "text": text, "check": False}
+    if capture_output:
+        kwargs["capture_output"] = True
+    if input is not None:
+        kwargs["input"] = input
+    elif not capture_output:
+        kwargs["stdin"] = subprocess.DEVNULL
+
     return subprocess.run(
         [
             sys.executable,
@@ -48,14 +59,7 @@ def run_timeout(
             str(rss_mb),
             *command,
         ],
-        cwd=cwd,
-        env=env,
-        capture_output=capture_output,
-        stdout=stdout,
-        stderr=stderr,
-        input=input,
-        text=text,
-        check=False,
+        **kwargs,
     )
 
 

--- a/tests/test_port_rereview_py.py
+++ b/tests/test_port_rereview_py.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.machinery
 import importlib.util
 import os
+import subprocess
 import tempfile
 from pathlib import Path
 from unittest import mock
@@ -102,6 +103,45 @@ with tempfile.TemporaryDirectory(prefix="port-rereview-") as temporary:
     ) as (completed, output):
         check(completed.returncode == 0 and output.stat().st_size == 2_000_000,
               "timeout capture keeps large child output file-backed")
+
+    read_fd, write_fd = os.pipe()
+    try:
+        stdin_check = subprocess.run(
+            [
+                sys.executable, "-c",
+                "import sys;"
+                f"sys.path.insert(0,{str(ROOT / 'lib')!r});"
+                "from timeout import run_timeout;"
+                "completed=run_timeout("
+                "[sys.executable,'-c','import sys;sys.stdin.read()'],"
+                "1,capture_output=True);"
+                "raise SystemExit(completed.returncode)",
+            ],
+            stdin=read_fd, capture_output=True, text=True, check=False,
+        )
+    finally:
+        for descriptor in (read_fd, write_fd):
+            os.close(descriptor)
+    check(
+        stdin_check.returncode == 0,
+        "timeout capture closes inherited stdin when no input is supplied",
+    )
+
+    warning_check = subprocess.run(
+        [
+            sys.executable, "-W", "error", "-c",
+            "import sys,warnings;"
+            f"sys.path.insert(0,{str(ROOT / 'lib')!r});"
+            "import timeout;"
+            "warnings.warn('unrelated warning',DeprecationWarning)",
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    check(
+        warning_check.returncode != 0
+        and "unrelated warning" in warning_check.stderr,
+        "importing timeout preserves the caller's deprecation-warning policy",
+    )
 
     probe = load_script("probe_rereview", ROOT / "bin" / "probe")
     multi = load_script("sanitizer_multi_rereview", ROOT / "bin" / "run-sanitizer-multi")


### PR DESCRIPTION
- lib/process_tree.py: add Darwin sysctl(KERN_PROCARGS2) fallback to inspect process environments on macOS without unprivileged ps -axEww permission errors.
- lib/timeout.py: suppress multi-threaded os.fork() deprecation warnings from polluting process outputs, default stdin to DEVNULL when input is None and capture_output is False, and fix kwargs handling when capture_output and input are both set.
- lib/benchmark_runner.py: set stdin=DEVNULL on un-walled benchmark cell executions to prevent child processes from inheriting caller stdin pipe and hanging.
- lib/llm_invoke.py: pass stdin=DEVNULL when input_text is None during CLI agent process execution.